### PR TITLE
Add EIP-712 action and card commit signature helpers

### DIFF
--- a/src/HeadsUpPokerEIP712.sol
+++ b/src/HeadsUpPokerEIP712.sol
@@ -9,15 +9,18 @@ contract HeadsUpPokerEIP712 {
     // ---------------------------------------------------------------------
     // Typehashes
     // ---------------------------------------------------------------------
-    bytes32 private constant EIP712DOMAIN_TYPEHASH = keccak256(
-        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,uint256 channelId)"
-    );
-    bytes32 private constant ACTION_TYPEHASH = keccak256(
-        "Action(uint256 channelId,uint256 handId,uint32 seq,uint8 street,uint8 action,uint128 amount,bytes32 prevHash)"
-    );
-    bytes32 private constant CARD_COMMIT_TYPEHASH = keccak256(
-        "CardCommit(uint256 channelId,uint256 handId,uint32 seq,uint8 role,uint8 index,bytes32 dealRef,bytes32 commitHash,bytes32 prevHash)"
-    );
+    bytes32 private constant EIP712DOMAIN_TYPEHASH =
+        keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,uint256 channelId)"
+        );
+    bytes32 private constant ACTION_TYPEHASH =
+        keccak256(
+            "Action(uint256 channelId,uint256 handId,uint32 seq,uint8 street,uint8 action,uint128 amount,bytes32 prevHash)"
+        );
+    bytes32 private constant CARD_COMMIT_TYPEHASH =
+        keccak256(
+            "CardCommit(uint256 channelId,uint256 handId,uint32 seq,uint8 role,uint8 index,bytes32 dealRef,bytes32 commitHash,bytes32 prevHash)"
+        );
     bytes32 private constant NAME_HASH = keccak256(bytes("HeadsUpPoker"));
     bytes32 private constant VERSION_HASH = keccak256(bytes("1"));
 
@@ -52,17 +55,20 @@ contract HeadsUpPokerEIP712 {
         return _domainSeparator(channelId);
     }
 
-    function _domainSeparator(uint256 channelId) internal view returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                EIP712DOMAIN_TYPEHASH,
-                NAME_HASH,
-                VERSION_HASH,
-                block.chainid,
-                address(this),
-                channelId
-            )
-        );
+    function _domainSeparator(
+        uint256 channelId
+    ) internal view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    EIP712DOMAIN_TYPEHASH,
+                    NAME_HASH,
+                    VERSION_HASH,
+                    block.chainid,
+                    address(this),
+                    channelId
+                )
+            );
     }
 
     // ---------------------------------------------------------------------
@@ -81,9 +87,14 @@ contract HeadsUpPokerEIP712 {
                 act.prevHash
             )
         );
-        return keccak256(
-            abi.encodePacked("\x19\x01", _domainSeparator(act.channelId), structHash)
-        );
+        return
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    _domainSeparator(act.channelId),
+                    structHash
+                )
+            );
     }
 
     function digestCardCommit(
@@ -102,9 +113,14 @@ contract HeadsUpPokerEIP712 {
                 cc.prevHash
             )
         );
-        return keccak256(
-            abi.encodePacked("\x19\x01", _domainSeparator(cc.channelId), structHash)
-        );
+        return
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    _domainSeparator(cc.channelId),
+                    structHash
+                )
+            );
     }
 
     // ---------------------------------------------------------------------
@@ -124,4 +140,3 @@ contract HeadsUpPokerEIP712 {
         return digestCardCommit(cc).recover(sig);
     }
 }
-

--- a/src/HeadsUpPokerEscrow.sol
+++ b/src/HeadsUpPokerEscrow.sol
@@ -25,18 +25,46 @@ contract HeadsUpPokerEscrow is ReentrancyGuard {
     // ---------------------------------------------------------------------
     // Events
     // ---------------------------------------------------------------------
-    event ChannelOpened(uint256 indexed channelId, address indexed player1, address indexed player2, uint256 amount);
-    event ChannelJoined(uint256 indexed channelId, address indexed player, uint256 amount);
-    event FoldSettled(uint256 indexed channelId, address indexed winner, uint256 amount);
-    event HoleCardsCommitted(uint256 indexed channelId, address indexed player, bytes32 commit);
+    event ChannelOpened(
+        uint256 indexed channelId,
+        address indexed player1,
+        address indexed player2,
+        uint256 amount
+    );
+    event ChannelJoined(
+        uint256 indexed channelId,
+        address indexed player,
+        uint256 amount
+    );
+    event FoldSettled(
+        uint256 indexed channelId,
+        address indexed winner,
+        uint256 amount
+    );
+    event HoleCardsCommitted(
+        uint256 indexed channelId,
+        address indexed player,
+        bytes32 commit
+    );
     event ShowdownStarted(uint256 indexed channelId);
-    event HoleCardsRevealed(uint256 indexed channelId, address indexed player, uint8 card1, uint8 card2);
-    event ShowdownFinalized(uint256 indexed channelId, address indexed winner, uint256 amount);
+    event HoleCardsRevealed(
+        uint256 indexed channelId,
+        address indexed player,
+        uint8 card1,
+        uint8 card2
+    );
+    event ShowdownFinalized(
+        uint256 indexed channelId,
+        address indexed winner,
+        uint256 amount
+    );
 
     // ---------------------------------------------------------------------
     // View helpers
     // ---------------------------------------------------------------------
-    function stacks(uint256 channelId) external view returns (uint256 p1, uint256 p2) {
+    function stacks(
+        uint256 channelId
+    ) external view returns (uint256 p1, uint256 p2) {
         Channel storage ch = channels[channelId];
         return (ch.deposit1, ch.deposit2);
     }
@@ -46,7 +74,10 @@ contract HeadsUpPokerEscrow is ReentrancyGuard {
     // ---------------------------------------------------------------------
 
     /// @notice Player1 opens a channel with an opponent by depositing ETH
-    function open(uint256 channelId, address opponent) external payable nonReentrant {
+    function open(
+        uint256 channelId,
+        address opponent
+    ) external payable nonReentrant {
         Channel storage ch = channels[channelId];
         require(ch.player1 == address(0), "EXISTS");
         require(opponent != address(0) && opponent != msg.sender, "BAD_OPP");
@@ -73,7 +104,10 @@ contract HeadsUpPokerEscrow is ReentrancyGuard {
     }
 
     /// @notice Winner claims the entire pot when opponent folds
-    function settleFold(uint256 channelId, address winner) external nonReentrant {
+    function settleFold(
+        uint256 channelId,
+        address winner
+    ) external nonReentrant {
         Channel storage ch = channels[channelId];
         require(!ch.showdown, "SHOWDOWN");
         require(winner == ch.player1 || winner == ch.player2, "NOT_PLAYER");
@@ -92,26 +126,43 @@ contract HeadsUpPokerEscrow is ReentrancyGuard {
     }
 
     /// @notice Player submits commitment to their hole cards to start showdown
-    function startShowdown(uint256 channelId, bytes32 commit) external nonReentrant {
+    function startShowdown(
+        uint256 channelId,
+        bytes32 commit
+    ) external nonReentrant {
         Channel storage ch = channels[channelId];
         require(ch.deposit1 > 0 && ch.deposit2 > 0, "NOT_READY");
-        require(msg.sender == ch.player1 || msg.sender == ch.player2, "NOT_PLAYER");
+        require(
+            msg.sender == ch.player1 || msg.sender == ch.player2,
+            "NOT_PLAYER"
+        );
         require(ch.holeCardCommit[msg.sender] == bytes32(0), "COMMITTED");
 
         ch.holeCardCommit[msg.sender] = commit;
         emit HoleCardsCommitted(channelId, msg.sender, commit);
 
-        if (ch.holeCardCommit[ch.player1] != bytes32(0) && ch.holeCardCommit[ch.player2] != bytes32(0)) {
+        if (
+            ch.holeCardCommit[ch.player1] != bytes32(0) &&
+            ch.holeCardCommit[ch.player2] != bytes32(0)
+        ) {
             ch.showdown = true;
             emit ShowdownStarted(channelId);
         }
     }
 
     /// @notice Reveal actual hole cards and verify against commitment
-    function revealHoleCards(uint256 channelId, uint8 card1, uint8 card2, bytes32 salt) external nonReentrant {
+    function revealHoleCards(
+        uint256 channelId,
+        uint8 card1,
+        uint8 card2,
+        bytes32 salt
+    ) external nonReentrant {
         Channel storage ch = channels[channelId];
         require(ch.showdown, "NO_SHOWDOWN");
-        require(msg.sender == ch.player1 || msg.sender == ch.player2, "NOT_PLAYER");
+        require(
+            msg.sender == ch.player1 || msg.sender == ch.player2,
+            "NOT_PLAYER"
+        );
         require(ch.revealedHoleCards[msg.sender].length == 0, "REVEALED");
 
         bytes32 commit = keccak256(abi.encodePacked(card1, card2, salt));
@@ -122,11 +173,18 @@ contract HeadsUpPokerEscrow is ReentrancyGuard {
     }
 
     /// @notice Finalize showdown and send pot to winner after both players revealed
-    function finalizeShowdown(uint256 channelId, address winner) external nonReentrant {
+    function finalizeShowdown(
+        uint256 channelId,
+        address winner
+    ) external nonReentrant {
         Channel storage ch = channels[channelId];
         require(ch.showdown, "NO_SHOWDOWN");
         require(!ch.finalized, "FINALIZED");
-        require(ch.revealedHoleCards[ch.player1].length > 0 && ch.revealedHoleCards[ch.player2].length > 0, "NOT_REVEALED");
+        require(
+            ch.revealedHoleCards[ch.player1].length > 0 &&
+                ch.revealedHoleCards[ch.player2].length > 0,
+            "NOT_REVEALED"
+        );
         require(winner == ch.player1 || winner == ch.player2, "NOT_PLAYER");
 
         // TODO: add verification that winner actually has the best hand

--- a/test/HeadsUpPokerEIP712.test.js
+++ b/test/HeadsUpPokerEIP712.test.js
@@ -2,8 +2,7 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("HeadsUpPokerEIP712", function () {
-    let helper;
-    let player1, player2;
+    let contract;
 
     const channelId = 7n;
     const mnemonic = "test test test test test test test test test test test junk";
@@ -27,7 +26,7 @@ describe("HeadsUpPokerEIP712", function () {
     beforeEach(async function () {
         [player1, player2] = await ethers.getSigners();
         const Helper = await ethers.getContractFactory("HeadsUpPokerEIP712");
-        helper = await Helper.deploy();
+        contract = await Helper.deploy();
     });
 
     function domainSeparator(chainId, verifyingContract, channelId) {
@@ -53,7 +52,7 @@ describe("HeadsUpPokerEIP712", function () {
         };
 
         const chainId = (await ethers.provider.getNetwork()).chainId;
-        const verifyingContract = await helper.getAddress();
+        const verifyingContract = await contract.getAddress();
         const domSep = domainSeparator(chainId, verifyingContract, channelId);
         const structHash = ethers.keccak256(
             ethers.AbiCoder.defaultAbiCoder().encode(
@@ -79,11 +78,11 @@ describe("HeadsUpPokerEIP712", function () {
         );
         const wallet1 = ethers.Wallet.fromPhrase(mnemonic, "m/44'/60'/0'/0/0");
         const sig = wallet1.signingKey.sign(digest).serialized;
-        const recovered = await helper.recoverActionSigner(action, sig);
+        const recovered = await contract.recoverActionSigner(action, sig);
         expect(recovered).to.equal(wallet1.address);
 
         const badAction = { ...action, channelId: channelId + 1n };
-        const badRecovered = await helper.recoverActionSigner(badAction, sig);
+        const badRecovered = await contract.recoverActionSigner(badAction, sig);
         expect(badRecovered).to.not.equal(wallet1.address);
     });
 
@@ -100,7 +99,7 @@ describe("HeadsUpPokerEIP712", function () {
         };
 
         const chainId = (await ethers.provider.getNetwork()).chainId;
-        const verifyingContract = await helper.getAddress();
+        const verifyingContract = await contract.getAddress();
         const domSep = domainSeparator(chainId, verifyingContract, channelId);
         const structHash = ethers.keccak256(
             ethers.AbiCoder.defaultAbiCoder().encode(
@@ -137,7 +136,7 @@ describe("HeadsUpPokerEIP712", function () {
         );
         const wallet2 = ethers.Wallet.fromPhrase(mnemonic, "m/44'/60'/0'/0/1");
         const sig = wallet2.signingKey.sign(digest).serialized;
-        const recovered = await helper.recoverCommitSigner(commit, sig);
+        const recovered = await contract.recoverCommitSigner(commit, sig);
         expect(recovered).to.equal(wallet2.address);
     });
 });


### PR DESCRIPTION
## Summary
- add `HeadsUpPokerEIP712` helper contract to compute EIP-712 digests for Action and CardCommit structs and recover signers
- implement domain separator bound to channelId and verifying contract
- add tests covering Action and CardCommit signature recovery

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa3e1925d88328b104b4757ebd3eab