### PR TITLE
Implement action replay validation

### DIFF
--- a/src/HeadsUpPokerActions.sol
+++ b/src/HeadsUpPokerActions.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+struct Action {
+    uint256 channelId;
+    uint256 handId;
+    uint32 seq;
+    uint8 street;
+    uint8 action;
+    uint128 amount;
+    bytes32 prevHash;
+}

--- a/src/HeadsUpPokerEIP712.sol
+++ b/src/HeadsUpPokerEIP712.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {Action} from "./HeadsUpPokerActions.sol";
 
 contract HeadsUpPokerEIP712 {
     using ECDSA for bytes32;
@@ -27,16 +28,6 @@ contract HeadsUpPokerEIP712 {
     // ---------------------------------------------------------------------
     // Struct definitions
     // ---------------------------------------------------------------------
-    struct Action {
-        uint256 channelId;
-        uint256 handId;
-        uint32 seq;
-        uint8 street;
-        uint8 action;
-        uint128 amount;
-        bytes32 prevHash;
-    }
-
     struct CardCommit {
         uint256 channelId;
         uint256 handId;
@@ -139,4 +130,6 @@ contract HeadsUpPokerEIP712 {
     ) external view returns (address) {
         return digestCardCommit(cc).recover(sig);
     }
+
+    // ---------------------------------------------------------------------
 }

--- a/src/HeadsUpPokerReplay.sol
+++ b/src/HeadsUpPokerReplay.sol
@@ -99,7 +99,10 @@ contract HeadsUpPokerReplay {
                     require(act.amount == callAmt, "CALL_AMT");
                     g.contrib[p] += act.amount;
                     g.total[p] += act.amount;
-                    require(g.total[p] <= maxDeposit[p], p == 0 ? "DEP_A" : "DEP_B");
+                    require(
+                        g.total[p] <= maxDeposit[p],
+                        p == 0 ? "DEP_A" : "DEP_B"
+                    );
                     g.stacks[p] -= act.amount;
                     if (g.stacks[p] == 0) g.allIn[p] = true;
                     g.toCall = 0;
@@ -143,10 +146,16 @@ contract HeadsUpPokerReplay {
                     require(act.amount >= need, "MIN_RAISE");
                 }
                 uint256 toCallBefore = g.toCall;
-                require(act.amount <= g.stacks[p] + toCallBefore, "RAISE_STACK");
+                require(
+                    act.amount <= g.stacks[p] + toCallBefore,
+                    "RAISE_STACK"
+                );
                 g.contrib[p] += act.amount;
                 g.total[p] += act.amount;
-                require(g.total[p] <= maxDeposit[p], p == 0 ? "DEP_A" : "DEP_B");
+                require(
+                    g.total[p] <= maxDeposit[p],
+                    p == 0 ? "DEP_A" : "DEP_B"
+                );
                 g.stacks[p] -= act.amount;
                 if (g.stacks[p] == 0) g.allIn[p] = true;
                 uint256 newDiff = g.contrib[p] - g.contrib[opp];

--- a/src/HeadsUpPokerReplay.sol
+++ b/src/HeadsUpPokerReplay.sol
@@ -32,9 +32,7 @@ contract HeadsUpPokerReplay {
     function replayAndGetEndState(
         Action[] calldata actions,
         uint256 stackA,
-        uint256 stackB,
-        uint256 depositA,
-        uint256 depositB
+        uint256 stackB
     ) external pure returns (End end, address folder) {
         require(actions.length >= 2, "NO_BLINDS");
 
@@ -61,8 +59,6 @@ contract HeadsUpPokerReplay {
         g.contrib[1] = bb.amount;
         g.total[0] = sb.amount;
         g.total[1] = bb.amount;
-        require(g.total[0] <= depositA, "DEP_A");
-        require(g.total[1] <= depositB, "DEP_B");
         if (g.stacks[0] == 0) g.allIn[0] = true;
         if (g.stacks[1] == 0) g.allIn[1] = true;
         g.actor = 0; // small blind acts first preflop
@@ -71,7 +67,7 @@ contract HeadsUpPokerReplay {
         g.lastRaise = bigBlind;
         g.checked = false;
 
-        uint256[2] memory maxDep = [depositA, depositB];
+        uint256[2] memory maxDeposit = [stackA, stackB];
 
         for (uint256 i = 2; i < actions.length; i++) {
             Action calldata act = actions[i];
@@ -103,7 +99,7 @@ contract HeadsUpPokerReplay {
                     require(act.amount == callAmt, "CALL_AMT");
                     g.contrib[p] += act.amount;
                     g.total[p] += act.amount;
-                    require(g.total[p] <= maxDep[p], p == 0 ? "DEP_A" : "DEP_B");
+                    require(g.total[p] <= maxDeposit[p], p == 0 ? "DEP_A" : "DEP_B");
                     g.stacks[p] -= act.amount;
                     if (g.stacks[p] == 0) g.allIn[p] = true;
                     g.toCall = 0;
@@ -150,7 +146,7 @@ contract HeadsUpPokerReplay {
                 require(act.amount <= g.stacks[p] + toCallBefore, "RAISE_STACK");
                 g.contrib[p] += act.amount;
                 g.total[p] += act.amount;
-                require(g.total[p] <= maxDep[p], p == 0 ? "DEP_A" : "DEP_B");
+                require(g.total[p] <= maxDeposit[p], p == 0 ? "DEP_A" : "DEP_B");
                 g.stacks[p] -= act.amount;
                 if (g.stacks[p] == 0) g.allIn[p] = true;
                 uint256 newDiff = g.contrib[p] - g.contrib[opp];

--- a/src/HeadsUpPokerReplay.sol
+++ b/src/HeadsUpPokerReplay.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {Action} from "./HeadsUpPokerActions.sol";
+
+contract HeadsUpPokerReplay {
+    enum End {
+        FOLD,
+        SHOWDOWN
+    }
+
+    uint8 private constant ACT_SMALL_BLIND = 0;
+    uint8 private constant ACT_BIG_BLIND = 1;
+    uint8 private constant ACT_FOLD = 2;
+    uint8 private constant ACT_CHECK_CALL = 3;
+    uint8 private constant ACT_BET_RAISE = 4;
+
+    struct Game {
+        uint256[2] stacks;
+        uint256[2] contrib;
+        uint256[2] total;
+        bool[2] allIn;
+        uint8 actor;
+        uint8 street;
+        uint256 toCall;
+        uint256 lastRaise;
+        bool checked;
+    }
+
+    /// @notice Replays a sequence of actions and returns the terminal state
+    /// @dev Reverts when an invalid transition is encountered
+    function replayAndGetEndState(
+        Action[] calldata actions,
+        uint256 stackA,
+        uint256 stackB,
+        uint256 depositA,
+        uint256 depositB
+    ) external pure returns (End end, address folder) {
+        require(actions.length >= 2, "NO_BLINDS");
+
+        Action calldata sb = actions[0];
+        require(sb.prevHash == bytes32(0), "SB_PREV");
+        require(sb.action == ACT_SMALL_BLIND, "SB_ACT");
+        require(sb.street == 0, "SB_STREET");
+        require(sb.amount > 0 && sb.amount <= stackA, "SB_AMT");
+
+        Action calldata bb = actions[1];
+        require(bb.seq > sb.seq, "SEQ1");
+        require(bb.prevHash == _hashAction(sb), "BB_PREV");
+        require(bb.action == ACT_BIG_BLIND, "BB_ACT");
+        require(bb.street == 0, "BB_STREET");
+        require(bb.amount == sb.amount * 2, "BB_AMT");
+        require(bb.amount <= stackB, "BB_STACK");
+
+        uint256 bigBlind = bb.amount;
+
+        Game memory g;
+        g.stacks[0] = stackA - sb.amount;
+        g.stacks[1] = stackB - bb.amount;
+        g.contrib[0] = sb.amount;
+        g.contrib[1] = bb.amount;
+        g.total[0] = sb.amount;
+        g.total[1] = bb.amount;
+        require(g.total[0] <= depositA, "DEP_A");
+        require(g.total[1] <= depositB, "DEP_B");
+        if (g.stacks[0] == 0) g.allIn[0] = true;
+        if (g.stacks[1] == 0) g.allIn[1] = true;
+        g.actor = 0; // small blind acts first preflop
+        g.street = 0;
+        g.toCall = g.contrib[1] - g.contrib[0];
+        g.lastRaise = bigBlind;
+        g.checked = false;
+
+        uint256[2] memory maxDep = [depositA, depositB];
+
+        for (uint256 i = 2; i < actions.length; i++) {
+            Action calldata act = actions[i];
+            Action calldata prev = actions[i - 1];
+
+            require(act.seq > prev.seq, "SEQ");
+            require(act.prevHash == _hashAction(prev), "PREV_HASH");
+            require(act.street == g.street, "BAD_STREET");
+            require(act.action > ACT_BIG_BLIND, "BLIND_ONLY_START");
+
+            uint256 p = g.actor;
+            uint256 opp = 1 - p;
+
+            require(!g.allIn[p], "PLAYER_ALLIN");
+
+            if (act.action == ACT_FOLD) {
+                require(act.amount == 0, "FOLD_AMT");
+                folder = p == 0 ? address(0) : address(1);
+                end = End.FOLD;
+                return (end, folder);
+            }
+
+            if (act.action == ACT_CHECK_CALL) {
+                if (g.toCall > 0) {
+                    uint256 callAmt = g.toCall;
+                    if (g.stacks[p] < callAmt) {
+                        callAmt = g.stacks[p];
+                    }
+                    require(act.amount == callAmt, "CALL_AMT");
+                    g.contrib[p] += act.amount;
+                    g.total[p] += act.amount;
+                    require(g.total[p] <= maxDep[p], p == 0 ? "DEP_A" : "DEP_B");
+                    g.stacks[p] -= act.amount;
+                    if (g.stacks[p] == 0) g.allIn[p] = true;
+                    g.toCall = 0;
+                    g.lastRaise = bigBlind;
+                    g.checked = false;
+                    if (g.allIn[0] && g.allIn[1]) {
+                        return (End.SHOWDOWN, address(0));
+                    }
+                    g.street++;
+                    require(g.street <= 3, "STREET_OVER");
+                    g.contrib[0] = 0;
+                    g.contrib[1] = 0;
+                    g.actor = 1;
+                    continue;
+                } else {
+                    require(act.amount == 0, "CHECK_AMT");
+                    if (g.checked) {
+                        g.street++;
+                        if (g.street == 4) {
+                            return (End.SHOWDOWN, address(0));
+                        }
+                        g.contrib[0] = 0;
+                        g.contrib[1] = 0;
+                        g.actor = 1;
+                        g.checked = false;
+                    } else {
+                        g.checked = true;
+                        g.actor = uint8(opp);
+                    }
+                    continue;
+                }
+            }
+
+            if (act.action == ACT_BET_RAISE) {
+                require(act.amount > 0, "RAISE_ZERO");
+                uint256 minRaise = g.lastRaise;
+                uint256 need = g.toCall + minRaise;
+                if (g.stacks[p] + g.toCall <= need) {
+                    require(act.amount == g.stacks[p], "RAISE_ALLIN_AMT");
+                } else {
+                    require(act.amount >= need, "MIN_RAISE");
+                }
+                uint256 toCallBefore = g.toCall;
+                require(act.amount <= g.stacks[p] + toCallBefore, "RAISE_STACK");
+                g.contrib[p] += act.amount;
+                g.total[p] += act.amount;
+                require(g.total[p] <= maxDep[p], p == 0 ? "DEP_A" : "DEP_B");
+                g.stacks[p] -= act.amount;
+                if (g.stacks[p] == 0) g.allIn[p] = true;
+                uint256 newDiff = g.contrib[p] - g.contrib[opp];
+                g.lastRaise = newDiff - toCallBefore;
+                require(g.lastRaise > 0, "RAISE_INC");
+                g.toCall = newDiff;
+                g.checked = false;
+                g.actor = uint8(opp);
+                continue;
+            }
+
+            revert("UNK_ACTION");
+        }
+
+        revert("HAND_NOT_DONE");
+    }
+
+    function _hashAction(Action calldata act) private pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    act.channelId,
+                    act.handId,
+                    act.seq,
+                    act.street,
+                    act.action,
+                    act.amount,
+                    act.prevHash
+                )
+            );
+    }
+}

--- a/src/HeadsUpPokerReplay.sol
+++ b/src/HeadsUpPokerReplay.sol
@@ -33,7 +33,7 @@ contract HeadsUpPokerReplay {
         Action[] calldata actions,
         uint256 stackA,
         uint256 stackB
-    ) external pure returns (End end, address folder) {
+    ) external pure returns (End end, uint8 folder) {
         require(actions.length >= 2, "NO_BLINDS");
 
         Action calldata sb = actions[0];
@@ -85,7 +85,7 @@ contract HeadsUpPokerReplay {
 
             if (act.action == ACT_FOLD) {
                 require(act.amount == 0, "FOLD_AMT");
-                folder = p == 0 ? address(0) : address(1);
+                folder = uint8(p);
                 end = End.FOLD;
                 return (end, folder);
             }
@@ -106,7 +106,7 @@ contract HeadsUpPokerReplay {
                     g.lastRaise = bigBlind;
                     g.checked = false;
                     if (g.allIn[0] && g.allIn[1]) {
-                        return (End.SHOWDOWN, address(0));
+                        return (End.SHOWDOWN, 0);
                     }
                     g.street++;
                     require(g.street <= 3, "STREET_OVER");
@@ -119,7 +119,7 @@ contract HeadsUpPokerReplay {
                     if (g.checked) {
                         g.street++;
                         if (g.street == 4) {
-                            return (End.SHOWDOWN, address(0));
+                            return (End.SHOWDOWN, 0);
                         }
                         g.contrib[0] = 0;
                         g.contrib[1] = 0;

--- a/test/HeadsUpPokerEIP712.test.js
+++ b/test/HeadsUpPokerEIP712.test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const { ACTION } = require("./actions");
 
 describe("HeadsUpPokerEIP712", function () {
     let contract;
@@ -46,7 +47,7 @@ describe("HeadsUpPokerEIP712", function () {
             handId: 1n,
             seq: 1,
             street: 1,
-            action: 3,
+            action: ACTION.CHECK_CALL,
             amount: 100n,
             prevHash: ethers.ZeroHash
         };

--- a/test/HeadsUpPokerReplay.test.js
+++ b/test/HeadsUpPokerReplay.test.js
@@ -1,0 +1,81 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+// Helper to build actions with proper hashes and sequence numbers
+function buildActions(specs) {
+    const abi = ethers.AbiCoder.defaultAbiCoder();
+    const channelId = 1n;
+    const handId = 1n;
+    let seq = 1;
+    let prevHash = ethers.ZeroHash;
+    const actions = [];
+    for (const spec of specs) {
+        const act = {
+            channelId,
+            handId,
+            seq: seq++,
+            street: spec.street,
+            action: spec.action,
+            amount: spec.amount,
+            prevHash
+        };
+        actions.push(act);
+        prevHash = ethers.keccak256(
+            abi.encode(
+                ["uint256", "uint256", "uint32", "uint8", "uint8", "uint128", "bytes32"],
+                [act.channelId, act.handId, act.seq, act.street, act.action, act.amount, act.prevHash]
+            )
+        );
+    }
+    return actions;
+}
+
+describe("HeadsUpPokerReplay", function () {
+    let replay;
+
+    beforeEach(async function () {
+        const Replay = await ethers.getContractFactory("HeadsUpPokerReplay");
+        replay = await Replay.deploy();
+    });
+
+    it("returns fold when small blind folds preflop", async function () {
+        // small blind, big blind, small blind folds
+        const actions = buildActions([
+            { street: 0, action: 0, amount: 1n },
+            { street: 0, action: 1, amount: 2n },
+            { street: 0, action: 2, amount: 0n }
+        ]);
+        const stackA = 10n;
+        const stackB = 10n;
+        const [end, folder] = await replay.replayAndGetEndState(actions, stackA, stackB);
+        expect(end).to.equal(0n); // End.FOLD
+        expect(folder).to.equal(ethers.ZeroAddress);
+    });
+
+    it("reaches showdown after checks on all streets", async function () {
+        // blinds, call, then check down to showdown
+        const actions = buildActions([
+            { street: 0, action: 0, amount: 1n }, // SB
+            { street: 0, action: 1, amount: 2n }, // BB
+            { street: 0, action: 3, amount: 1n }, // SB calls
+            { street: 1, action: 3, amount: 0n }, // BB checks
+            { street: 1, action: 3, amount: 0n }, // SB checks -> move to street 2
+            { street: 2, action: 3, amount: 0n }, // BB checks
+            { street: 2, action: 3, amount: 0n }, // SB checks -> move to street 3
+            { street: 3, action: 3, amount: 0n }, // BB checks
+            { street: 3, action: 3, amount: 0n }  // SB checks -> showdown
+        ]);
+        const [end, folder] = await replay.replayAndGetEndState(actions, 10n, 10n);
+        expect(end).to.equal(1n); // End.SHOWDOWN
+        expect(folder).to.equal(ethers.ZeroAddress);
+    });
+
+    it("reverts when big blind amount is incorrect", async function () {
+        // big blind should be exactly twice the small blind
+        const actions = buildActions([
+            { street: 0, action: 0, amount: 1n },
+            { street: 0, action: 1, amount: 3n } // wrong amount
+        ]);
+        await expect(replay.replayAndGetEndState(actions, 10n, 10n)).to.be.revertedWith("BB_AMT");
+    });
+});

--- a/test/HeadsUpPokerReplay.test.js
+++ b/test/HeadsUpPokerReplay.test.js
@@ -50,7 +50,7 @@ describe("HeadsUpPokerReplay", function () {
         const stackB = 10n;
         const [end, folder] = await replay.replayAndGetEndState(actions, stackA, stackB);
         expect(end).to.equal(0n); // End.FOLD
-        expect(folder).to.equal(ethers.ZeroAddress);
+        expect(folder).to.equal(0n);
     });
 
     it("reaches showdown after checks on all streets", async function () {
@@ -68,7 +68,7 @@ describe("HeadsUpPokerReplay", function () {
         ]);
         const [end, folder] = await replay.replayAndGetEndState(actions, 10n, 10n);
         expect(end).to.equal(1n); // End.SHOWDOWN
-        expect(folder).to.equal(ethers.ZeroAddress);
+        expect(folder).to.equal(0n);
     });
 
     it("reverts when big blind amount is incorrect", async function () {

--- a/test/HeadsUpPokerReplay.test.js
+++ b/test/HeadsUpPokerReplay.test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const { ACTION } = require("./actions");
 
 // Helper to build actions with proper hashes and sequence numbers
 function buildActions(specs) {
@@ -41,9 +42,9 @@ describe("HeadsUpPokerReplay", function () {
     it("returns fold when small blind folds preflop", async function () {
         // small blind, big blind, small blind folds
         const actions = buildActions([
-            { street: 0, action: 0, amount: 1n },
-            { street: 0, action: 1, amount: 2n },
-            { street: 0, action: 2, amount: 0n }
+            { street: 0, action: ACTION.SMALL_BLIND, amount: 1n },
+            { street: 0, action: ACTION.BIG_BLIND, amount: 2n },
+            { street: 0, action: ACTION.FOLD, amount: 0n }
         ]);
         const stackA = 10n;
         const stackB = 10n;
@@ -55,15 +56,15 @@ describe("HeadsUpPokerReplay", function () {
     it("reaches showdown after checks on all streets", async function () {
         // blinds, call, then check down to showdown
         const actions = buildActions([
-            { street: 0, action: 0, amount: 1n }, // SB
-            { street: 0, action: 1, amount: 2n }, // BB
-            { street: 0, action: 3, amount: 1n }, // SB calls
-            { street: 1, action: 3, amount: 0n }, // BB checks
-            { street: 1, action: 3, amount: 0n }, // SB checks -> move to street 2
-            { street: 2, action: 3, amount: 0n }, // BB checks
-            { street: 2, action: 3, amount: 0n }, // SB checks -> move to street 3
-            { street: 3, action: 3, amount: 0n }, // BB checks
-            { street: 3, action: 3, amount: 0n }  // SB checks -> showdown
+            { street: 0, action: ACTION.SMALL_BLIND, amount: 1n }, // SB
+            { street: 0, action: ACTION.BIG_BLIND, amount: 2n }, // BB
+            { street: 0, action: ACTION.CHECK_CALL, amount: 1n }, // SB calls
+            { street: 1, action: ACTION.CHECK_CALL, amount: 0n }, // BB checks
+            { street: 1, action: ACTION.CHECK_CALL, amount: 0n }, // SB checks -> move to street 2
+            { street: 2, action: ACTION.CHECK_CALL, amount: 0n }, // BB checks
+            { street: 2, action: ACTION.CHECK_CALL, amount: 0n }, // SB checks -> move to street 3
+            { street: 3, action: ACTION.CHECK_CALL, amount: 0n }, // BB checks
+            { street: 3, action: ACTION.CHECK_CALL, amount: 0n }  // SB checks -> showdown
         ]);
         const [end, folder] = await replay.replayAndGetEndState(actions, 10n, 10n);
         expect(end).to.equal(1n); // End.SHOWDOWN
@@ -73,8 +74,8 @@ describe("HeadsUpPokerReplay", function () {
     it("reverts when big blind amount is incorrect", async function () {
         // big blind should be exactly twice the small blind
         const actions = buildActions([
-            { street: 0, action: 0, amount: 1n },
-            { street: 0, action: 1, amount: 3n } // wrong amount
+            { street: 0, action: ACTION.SMALL_BLIND, amount: 1n },
+            { street: 0, action: ACTION.BIG_BLIND, amount: 3n } // wrong amount
         ]);
         await expect(replay.replayAndGetEndState(actions, 10n, 10n)).to.be.revertedWith("BB_AMT");
     });

--- a/test/actions.js
+++ b/test/actions.js
@@ -1,0 +1,9 @@
+const ACTION = {
+  SMALL_BLIND: 0,
+  BIG_BLIND: 1,
+  FOLD: 2,
+  CHECK_CALL: 3,
+  BET_RAISE: 4
+};
+
+module.exports = { ACTION };


### PR DESCRIPTION
## Summary
- move action replay logic into dedicated `HeadsUpPokerReplay` contract
- share `Action` struct and enforce per-player deposit caps during replay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa428740e083288022e2ce1d9bd7b5