### PR TITLE
Adopt OZ EIP712 and include typehash in action hashes

### DIFF
--- a/src/HeadsUpPokerReplay.sol
+++ b/src/HeadsUpPokerReplay.sol
@@ -15,6 +15,11 @@ contract HeadsUpPokerReplay {
     uint8 private constant ACT_CHECK_CALL = 3;
     uint8 private constant ACT_BET_RAISE = 4;
 
+    bytes32 private constant ACTION_TYPEHASH =
+        keccak256(
+            "Action(uint256 channelId,uint256 handId,uint32 seq,uint8 action,uint128 amount,bytes32 prevHash)"
+        );
+
     struct Game {
         uint256[2] stacks;
         uint256[2] contrib;
@@ -175,6 +180,7 @@ contract HeadsUpPokerReplay {
         return
             keccak256(
                 abi.encode(
+                    ACTION_TYPEHASH,
                     act.channelId,
                     act.handId,
                     act.seq,

--- a/test/HeadsUpPokerEIP712.test.js
+++ b/test/HeadsUpPokerEIP712.test.js
@@ -10,7 +10,7 @@ describe("HeadsUpPokerEIP712", function () {
 
     const DOMAIN_TYPEHASH = ethers.keccak256(
         ethers.toUtf8Bytes(
-            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,uint256 channelId)"
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
         )
     );
     const ACTION_TYPEHASH = ethers.keccak256(
@@ -30,13 +30,13 @@ describe("HeadsUpPokerEIP712", function () {
         contract = await Helper.deploy();
     });
 
-    function domainSeparator(chainId, verifyingContract, channelId) {
+    function domainSeparator(chainId, verifyingContract) {
         const nameHash = ethers.keccak256(ethers.toUtf8Bytes("HeadsUpPoker"));
         const versionHash = ethers.keccak256(ethers.toUtf8Bytes("1"));
         return ethers.keccak256(
             ethers.AbiCoder.defaultAbiCoder().encode(
-                ["bytes32", "bytes32", "bytes32", "uint256", "address", "uint256"],
-                [DOMAIN_TYPEHASH, nameHash, versionHash, chainId, verifyingContract, channelId]
+                ["bytes32", "bytes32", "bytes32", "uint256", "address"],
+                [DOMAIN_TYPEHASH, nameHash, versionHash, chainId, verifyingContract]
             )
         );
     }
@@ -53,7 +53,7 @@ describe("HeadsUpPokerEIP712", function () {
 
         const chainId = (await ethers.provider.getNetwork()).chainId;
         const verifyingContract = await contract.getAddress();
-        const domSep = domainSeparator(chainId, verifyingContract, channelId);
+        const domSep = domainSeparator(chainId, verifyingContract);
         const structHash = ethers.keccak256(
             ethers.AbiCoder.defaultAbiCoder().encode(
                 ["bytes32", "uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
@@ -99,7 +99,7 @@ describe("HeadsUpPokerEIP712", function () {
 
         const chainId = (await ethers.provider.getNetwork()).chainId;
         const verifyingContract = await contract.getAddress();
-        const domSep = domainSeparator(chainId, verifyingContract, channelId);
+        const domSep = domainSeparator(chainId, verifyingContract);
         const structHash = ethers.keccak256(
             ethers.AbiCoder.defaultAbiCoder().encode(
                 [

--- a/test/HeadsUpPokerReplay.test.js
+++ b/test/HeadsUpPokerReplay.test.js
@@ -2,6 +2,12 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { ACTION } = require("./actions");
 
+const ACTION_TYPEHASH = ethers.keccak256(
+    ethers.toUtf8Bytes(
+        "Action(uint256 channelId,uint256 handId,uint32 seq,uint8 action,uint128 amount,bytes32 prevHash)"
+    )
+);
+
 // Helper to build actions with proper hashes and sequence numbers
 function buildActions(specs) {
     const abi = ethers.AbiCoder.defaultAbiCoder();
@@ -22,8 +28,16 @@ function buildActions(specs) {
         actions.push(act);
         prevHash = ethers.keccak256(
             abi.encode(
-                ["uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
-                [act.channelId, act.handId, act.seq, act.action, act.amount, act.prevHash]
+                ["bytes32", "uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
+                [
+                    ACTION_TYPEHASH,
+                    act.channelId,
+                    act.handId,
+                    act.seq,
+                    act.action,
+                    act.amount,
+                    act.prevHash
+                ]
             )
         );
     }
@@ -214,8 +228,16 @@ describe("HeadsUpPokerReplay", function () {
                 amount: 2n,
                 prevHash: ethers.keccak256(
                     ethers.AbiCoder.defaultAbiCoder().encode(
-                        ["uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
-                        [sbAction.channelId, sbAction.handId, sbAction.seq, sbAction.action, sbAction.amount, sbAction.prevHash]
+                        ["bytes32", "uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
+                        [
+                            ACTION_TYPEHASH,
+                            sbAction.channelId,
+                            sbAction.handId,
+                            sbAction.seq,
+                            sbAction.action,
+                            sbAction.amount,
+                            sbAction.prevHash
+                        ]
                     )
                 )
             };
@@ -254,8 +276,16 @@ describe("HeadsUpPokerReplay", function () {
                 amount: 2n,
                 prevHash: ethers.keccak256(
                     ethers.AbiCoder.defaultAbiCoder().encode(
-                        ["uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
-                        [sbAction.channelId, sbAction.handId, sbAction.seq, sbAction.action, sbAction.amount, sbAction.prevHash]
+                        ["bytes32", "uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
+                        [
+                            ACTION_TYPEHASH,
+                            sbAction.channelId,
+                            sbAction.handId,
+                            sbAction.seq,
+                            sbAction.action,
+                            sbAction.amount,
+                            sbAction.prevHash
+                        ]
                     )
                 )
             };
@@ -295,8 +325,16 @@ describe("HeadsUpPokerReplay", function () {
                 amount: 0n,
                 prevHash: ethers.keccak256(
                     ethers.AbiCoder.defaultAbiCoder().encode(
-                        ["uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
-                        [actions[1].channelId, actions[1].handId, actions[1].seq, actions[1].action, actions[1].amount, actions[1].prevHash]
+                        ["bytes32", "uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
+                        [
+                            ACTION_TYPEHASH,
+                            actions[1].channelId,
+                            actions[1].handId,
+                            actions[1].seq,
+                            actions[1].action,
+                            actions[1].amount,
+                            actions[1].prevHash
+                        ]
                     )
                 )
             };
@@ -350,8 +388,16 @@ describe("HeadsUpPokerReplay", function () {
                 amount: 0n,
                 prevHash: ethers.keccak256(
                     ethers.AbiCoder.defaultAbiCoder().encode(
-                        ["uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
-                        [actions[1].channelId, actions[1].handId, actions[1].seq, actions[1].action, actions[1].amount, actions[1].prevHash]
+                        ["bytes32", "uint256", "uint256", "uint32", "uint8", "uint128", "bytes32"],
+                        [
+                            ACTION_TYPEHASH,
+                            actions[1].channelId,
+                            actions[1].handId,
+                            actions[1].seq,
+                            actions[1].action,
+                            actions[1].amount,
+                            actions[1].prevHash
+                        ]
                     )
                 )
             };


### PR DESCRIPTION
## Summary
- use OpenZeppelin `EIP712`/`ECDSA` for typed data hashing and signature recovery
- remove `channelId` from the EIP712 domain
- add struct `TYPEHASH` when computing action and commit hashes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb2a9b8c08328ae3fbd90bc484497