### PR TITLE
Add per-hand genesis hash for action chain

### DIFF
--- a/src/HeadsUpPokerReplay.sol
+++ b/src/HeadsUpPokerReplay.sol
@@ -27,6 +27,13 @@ contract HeadsUpPokerReplay {
         bool checked;
     }
 
+    function handGenesis(
+        uint256 chId,
+        uint256 handId
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked("HUP_GENESIS", chId, handId));
+    }
+
     /// @notice Replays a sequence of actions and returns the terminal state
     /// @dev Reverts when an invalid transition is encountered
     function replayAndGetEndState(
@@ -37,7 +44,10 @@ contract HeadsUpPokerReplay {
         require(actions.length >= 2, "NO_BLINDS");
 
         Action calldata sb = actions[0];
-        require(sb.prevHash == bytes32(0), "SB_PREV");
+        require(
+            sb.prevHash == handGenesis(sb.channelId, sb.handId),
+            "SB_PREV"
+        );
         require(sb.action == ACT_SMALL_BLIND, "SB_ACT");
         require(sb.amount > 0 && sb.amount <= stackA, "SB_AMT");
 

--- a/test/HeadsUpPokerEIP712.test.js
+++ b/test/HeadsUpPokerEIP712.test.js
@@ -48,7 +48,12 @@ describe("HeadsUpPokerEIP712", function () {
             seq: 1,
             action: ACTION.CHECK_CALL,
             amount: 100n,
-            prevHash: ethers.ZeroHash
+            prevHash: ethers.keccak256(
+                ethers.solidityPacked(
+                    ["string", "uint256", "uint256"],
+                    ["HUP_GENESIS", channelId, 1n]
+                )
+            )
         };
 
         const chainId = (await ethers.provider.getNetwork()).chainId;

--- a/test/HeadsUpPokerReplay.test.js
+++ b/test/HeadsUpPokerReplay.test.js
@@ -2,13 +2,17 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { ACTION } = require("./actions");
 
+const GENESIS = ethers.keccak256(
+    ethers.solidityPacked(["string", "uint256", "uint256"], ["HUP_GENESIS", 1n, 1n])
+);
+
 // Helper to build actions with proper hashes and sequence numbers
 function buildActions(specs) {
     const abi = ethers.AbiCoder.defaultAbiCoder();
     const channelId = 1n;
     const handId = 1n;
     let seq = 1;
-    let prevHash = ethers.ZeroHash;
+    let prevHash = GENESIS;
     const actions = [];
     for (const spec of specs) {
         const act = {
@@ -109,7 +113,7 @@ describe("HeadsUpPokerReplay", function () {
             await expect(replay.replayAndGetEndState(actions, 10n, 10n)).to.be.revertedWith("NO_BLINDS");
         });
 
-        it("reverts when small blind has non-zero prevHash", async function () {
+        it("reverts when small blind prevHash is incorrect", async function () {
             const actions = [
                 {
                     channelId: 1n,
@@ -117,7 +121,7 @@ describe("HeadsUpPokerReplay", function () {
                     seq: 1,
                     action: ACTION.SMALL_BLIND,
                     amount: 1n,
-                    prevHash: ethers.keccak256("0x1234") // Should be zero
+                    prevHash: ethers.keccak256("0x1234") // Should be genesis
                 },
                 {
                     channelId: 1n,
@@ -125,7 +129,7 @@ describe("HeadsUpPokerReplay", function () {
                     seq: 1,
                     action: ACTION.BIG_BLIND,
                     amount: 1n,
-                    prevHash: ethers.ZeroHash
+                    prevHash: GENESIS
                 }
             ];
             await expect(replay.replayAndGetEndState(actions, 10n, 10n)).to.be.revertedWith("SB_PREV");
@@ -139,7 +143,7 @@ describe("HeadsUpPokerReplay", function () {
                     seq: 1,
                     action: ACTION.BIG_BLIND, // Should be SMALL_BLIND
                     amount: 1n,
-                    prevHash: ethers.ZeroHash
+                    prevHash: GENESIS
                 },
                 {
                     channelId: 1n,
@@ -147,7 +151,7 @@ describe("HeadsUpPokerReplay", function () {
                     seq: 1,
                     action: ACTION.BIG_BLIND,
                     amount: 1n,
-                    prevHash: ethers.ZeroHash
+                    prevHash: GENESIS
                 }
             ];
             await expect(replay.replayAndGetEndState(actions, 10n, 10n)).to.be.revertedWith("SB_ACT");
@@ -161,7 +165,7 @@ describe("HeadsUpPokerReplay", function () {
                     seq: 1,
                     action: ACTION.SMALL_BLIND,
                     amount: 0n, // Should be > 0
-                    prevHash: ethers.ZeroHash
+                    prevHash: GENESIS
                 },
                 {
                     channelId: 1n,
@@ -169,7 +173,7 @@ describe("HeadsUpPokerReplay", function () {
                     seq: 1,
                     action: ACTION.BIG_BLIND,
                     amount: 1n,
-                    prevHash: ethers.ZeroHash
+                    prevHash: GENESIS
                 }
             ];
             await expect(replay.replayAndGetEndState(actions, 10n, 10n)).to.be.revertedWith("SB_AMT");
@@ -183,7 +187,7 @@ describe("HeadsUpPokerReplay", function () {
                     seq: 1,
                     action: ACTION.SMALL_BLIND,
                     amount: 11n, // Exceeds stack of 10
-                    prevHash: ethers.ZeroHash
+                    prevHash: GENESIS
                 },
                 {
                     channelId: 1n,
@@ -191,7 +195,7 @@ describe("HeadsUpPokerReplay", function () {
                     seq: 1,
                     action: ACTION.BIG_BLIND,
                     amount: 1n,
-                    prevHash: ethers.ZeroHash
+                    prevHash: GENESIS
                 }
             ];
             await expect(replay.replayAndGetEndState(actions, 10n, 10n)).to.be.revertedWith("SB_AMT");
@@ -204,7 +208,7 @@ describe("HeadsUpPokerReplay", function () {
                 seq: 5,
                 action: ACTION.SMALL_BLIND,
                 amount: 1n,
-                prevHash: ethers.ZeroHash
+                prevHash: GENESIS
             };
             const bbAction = {
                 channelId: 1n,
@@ -244,7 +248,7 @@ describe("HeadsUpPokerReplay", function () {
                 seq: 1,
                 action: ACTION.SMALL_BLIND,
                 amount: 1n,
-                prevHash: ethers.ZeroHash
+                prevHash: GENESIS
             };
             const bbAction = {
                 channelId: 1n,


### PR DESCRIPTION
## Summary
- add `handGenesis` helper to seed each hand's action chain
- enforce small blind to reference genesis hash
- update tests to compute and use per-hand genesis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb408013883289f8943e12f82d1ab