### PR TITLE
Add GitHub Action for pull request tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add a CI workflow that runs on pull request events
- install Node.js dependencies with npm ci and execute the Hardhat test suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d342bc03548328808dc22831893cb4